### PR TITLE
Gradle: Fix build script to work with Gradle 8.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,15 @@ dependencies {
 		junit('junit:junit:4.11') // Hamcrest is automatically included as transitive dependency.
 	else
 		junit files('/usr/share/java/junit4.jar', '/usr/share/java/hamcrest-core.jar')
-	testImplementation configurations.junit
+}
+configurations {
+	// This adds the dependencies of the configuration "junit" to the classpath of the
+	// configuration "testImplementation", which is used when compiling the unit tests.
+	// Effectively this means the JUnit JARs are added to the classpath when compiling the tests,
+	// which is necessary because they use the JUnit classes.
+	// (In previous Gradle versions it could be specified at dependencies {}, this unfortunately
+	// isn't possible anymore, hence this poorly readable code which needs this large comment ...)
+	testImplementation.extendsFrom junit
 }
 
 task compileDb4o(type: Exec) {

--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ tasks.create("testJar", Jar) // TODO: Performance: Use register() once my Gradle
 	reproducibleFileOrder = true
 	duplicatesStrategy = "fail"
 	archiveBaseName = (jarType == 'testJar') ? 'Freetalk-with-unit-tests' : 'Freetalk'
-	destinationDir = new File(projectDir, (jarType == 'testJar') ? "build-test" : "dist")
+	destinationDirectory = new File(projectDir, (jarType == 'testJar') ? "build-test" : "dist")
 	manifest { attributes("Plugin-Main-Class": "plugins.Freetalk.Freetalk") }
 	
 	// Now define the actual contents of the JARs.

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,6 @@ dependencies {
 		junit('junit:junit:4.11') // Hamcrest is automatically included as transitive dependency.
 	else
 		junit files('/usr/share/java/junit4.jar', '/usr/share/java/hamcrest-core.jar')
-	testImplementation configurations.junit
 }
 
 task compileDb4o(type: Exec) {

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ tasks.create("testJar", Jar) // TODO: Performance: Use register() once my Gradle
 	preserveFileTimestamps = false
 	reproducibleFileOrder = true
 	duplicatesStrategy = "fail"
-	baseName = (jarType == 'testJar') ? 'Freetalk-with-unit-tests' : 'Freetalk'
+	archiveBaseName = (jarType == 'testJar') ? 'Freetalk-with-unit-tests' : 'Freetalk'
 	destinationDir = new File(projectDir, (jarType == 'testJar') ? "build-test" : "dist")
 	manifest { attributes("Plugin-Main-Class": "plugins.Freetalk.Freetalk") }
 	

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 		junit('junit:junit:4.11') // Hamcrest is automatically included as transitive dependency.
 	else
 		junit files('/usr/share/java/junit4.jar', '/usr/share/java/hamcrest-core.jar')
+	testImplementation configurations.junit
 }
 
 task compileDb4o(type: Exec) {


### PR DESCRIPTION
_Please merge with `--ff-only` into `master`._

---

Notice: The CI tests will still fail on Windows due to unrelated issues, these will be fixed by a following PR.