### PR TITLE
GitHub Actions part 14: Fix CI tests always failing on Windows

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -151,18 +151,18 @@ jobs:
         echo 'fred version:'
         java -classpath '../fred/build/output/freenet.jar' 'freenet.node.Version'
         rm -f ./gradle ./gradlew
-#        if [ "${{runner.os}}" = 'Windows' ] ; then
+        #if [ "${{runner.os}}" = 'Windows' ] ; then
             # TODO: Code quality: Workaround for "gradle" command existing on GitHub Actions on
             # Windows but failing weirdly when we actually use it, as of 2021-08-19. Remove once it
             # is fixed.
             # When removing it, also remove the caching of the Gradle binaries which
             # was added by commit 849d2ee94474bf2ec33a29041289b8f4642fe45d
-#            ln --symbolic -- "$GITHUB_WORKSPACE/fred/gradle/" ./gradle
-#            ln --symbolic -- "$GITHUB_WORKSPACE/fred/gradlew" ./gradlew
-#        else
+        #    ln --symbolic -- "$GITHUB_WORKSPACE/fred/gradle/" ./gradle
+        #    ln --symbolic -- "$GITHUB_WORKSPACE/fred/gradlew" ./gradlew
+        #else
             # GitHub Actions does seem to ship the most recent Gradle so we don't download our own.
             ln -s -- "$(which gradle)" ./gradlew
-#        fi
+        #fi
         ./gradlew --version
         if [ "${{runner.os}}" != 'Linux' ] ; then
             # We can't obtain the dependencies from /usr/share so download them instead.

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -75,10 +75,7 @@ jobs:
       id: cache
       uses: actions/cache@v3
       with:
-        path: |
-          fred/build/output/
-          fred/gradle/  # fred's Gradle binaries are also used for Freetalk's compilation
-          fred/gradlew
+        path: fred/build/output/
         # The key must include the hash of the file to ensure the cache is invalidated whenever the
         # file contents change.
         #
@@ -150,26 +147,16 @@ jobs:
         echo 'Checksums of fred JARs:' ; sha256sum ../fred/build/output/*
         echo 'fred version:'
         java -classpath '../fred/build/output/freenet.jar' 'freenet.node.Version'
-        rm -f ./gradle ./gradlew
-        #if [ "${{runner.os}}" = 'Windows' ] ; then
-            # TODO: Code quality: Workaround for "gradle" command existing on GitHub Actions on
-            # Windows but failing weirdly when we actually use it, as of 2021-08-19. Remove once it
-            # is fixed.
-            # When removing it, also remove the caching of the Gradle binaries which
-            # was added by commit 849d2ee94474bf2ec33a29041289b8f4642fe45d
-        #    ln --symbolic -- "$GITHUB_WORKSPACE/fred/gradle/" ./gradle
-        #    ln --symbolic -- "$GITHUB_WORKSPACE/fred/gradlew" ./gradlew
-        #else
-            # GitHub Actions does seem to ship the most recent Gradle so we don't download our own.
-        #    ln -s -- "$(which gradle)" ./gradlew
-        #fi
+        echo 'gradle version:'
         gradle --version
+        
         if [ "${{runner.os}}" != 'Linux' ] ; then
             # We can't obtain the dependencies from /usr/share so download them instead.
             export FREETALK__DOWNLOAD_DEPENDENCIES=1
         fi
         # To test the Ant and Gradle builders against each other uncomment the following.
-        # (The scripts will use the ./gradlew we've installed so we can ensure the latest Gradle works.)
+        # (The scripts will use ./gradlew if there is one so we can ensure a specific Gradle version
+        # works if that becomes necessary someday.)
         # FIXME: Do this because this script has been converted from Travis CI to GitHub Actions.
         ## - tools/compare-gradle-jars-with-ant-jars
         ## - tools/compare-gradle-tests-with-ant-tests

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -151,18 +151,18 @@ jobs:
         echo 'fred version:'
         java -classpath '../fred/build/output/freenet.jar' 'freenet.node.Version'
         rm -f ./gradle ./gradlew
-        if [ "${{runner.os}}" = 'Windows' ] ; then
+#        if [ "${{runner.os}}" = 'Windows' ] ; then
             # TODO: Code quality: Workaround for "gradle" command existing on GitHub Actions on
             # Windows but failing weirdly when we actually use it, as of 2021-08-19. Remove once it
             # is fixed.
             # When removing it, also remove the caching of the Gradle binaries which
             # was added by commit 849d2ee94474bf2ec33a29041289b8f4642fe45d
-            ln --symbolic -- "$GITHUB_WORKSPACE/fred/gradle/" ./gradle
-            ln --symbolic -- "$GITHUB_WORKSPACE/fred/gradlew" ./gradlew
-        else
+#            ln --symbolic -- "$GITHUB_WORKSPACE/fred/gradle/" ./gradle
+#            ln --symbolic -- "$GITHUB_WORKSPACE/fred/gradlew" ./gradlew
+#        else
             # GitHub Actions does seem to ship the most recent Gradle so we don't download our own.
             ln -s -- "$(which gradle)" ./gradlew
-        fi
+#        fi
         ./gradlew --version
         if [ "${{runner.os}}" != 'Linux' ] ; then
             # We can't obtain the dependencies from /usr/share so download them instead.

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -161,9 +161,9 @@ jobs:
         #    ln --symbolic -- "$GITHUB_WORKSPACE/fred/gradlew" ./gradlew
         #else
             # GitHub Actions does seem to ship the most recent Gradle so we don't download our own.
-            ln -s -- "$(which gradle)" ./gradlew
+        #    ln -s -- "$(which gradle)" ./gradlew
         #fi
-        ./gradlew --version
+        gradle --version
         if [ "${{runner.os}}" != 'Linux' ] ; then
             # We can't obtain the dependencies from /usr/share so download them instead.
             export FREETALK__DOWNLOAD_DEPENDENCIES=1
@@ -175,7 +175,7 @@ jobs:
         ## - tools/compare-gradle-tests-with-ant-tests
         # Show stdout/stderr so random seeds of failed tests can be obtained by developers to
         # reproduce failed test runs. Also prevents the 10 minute build timeout.
-        FREETALK__SHOW_GRADLE_TEST_OUTPUT=1 ./gradlew clean test jar
+        FREETALK__SHOW_GRADLE_TEST_OUTPUT=1 gradle clean test jar
 
 # FIXME: Adapt to Freetalk and GitHub Actions (is Travis CI code currently) and enable.
 # Will require adding "python3-pip" to the list of apt packages to install, see above at

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,15 @@ dependencies {
 		junit('junit:junit:4.11') // Hamcrest is automatically included as transitive dependency.
 	else
 		junit files('/usr/share/java/junit4.jar', '/usr/share/java/hamcrest-core.jar')
-	testImplementation configurations.junit
+}
+configurations {
+	// This adds the dependencies of the configuration "junit" to the classpath of the
+	// configuration "testImplementation", which is used when compiling the unit tests.
+	// Effectively this means the JUnit JARs are added to the classpath when compiling the tests,
+	// which is necessary because they use the JUnit classes.
+	// (In previous Gradle versions it could be specified at dependencies {}, this unfortunately
+	// isn't possible anymore, hence this poorly readable code which needs this large comment ...)
+	testImplementation.extendsFrom junit
 }
 
 task compileDb4o(type: Exec) {

--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ tasks.create("testJar", Jar) // TODO: Performance: Use register() once my Gradle
 	reproducibleFileOrder = true
 	duplicatesStrategy = "fail"
 	archiveBaseName = (jarType == 'testJar') ? 'Freetalk-with-unit-tests' : 'Freetalk'
-	destinationDir = new File(projectDir, (jarType == 'testJar') ? "build-test" : "dist")
+	destinationDirectory = new File(projectDir, (jarType == 'testJar') ? "build-test" : "dist")
 	manifest { attributes("Plugin-Main-Class": "plugins.Freetalk.Freetalk") }
 	
 	// Now define the actual contents of the JARs.

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,6 @@ dependencies {
 		junit('junit:junit:4.11') // Hamcrest is automatically included as transitive dependency.
 	else
 		junit files('/usr/share/java/junit4.jar', '/usr/share/java/hamcrest-core.jar')
-	testImplementation configurations.junit
 }
 
 task compileDb4o(type: Exec) {

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ tasks.create("testJar", Jar) // TODO: Performance: Use register() once my Gradle
 	preserveFileTimestamps = false
 	reproducibleFileOrder = true
 	duplicatesStrategy = "fail"
-	baseName = (jarType == 'testJar') ? 'Freetalk-with-unit-tests' : 'Freetalk'
+	archiveBaseName = (jarType == 'testJar') ? 'Freetalk-with-unit-tests' : 'Freetalk'
 	destinationDir = new File(projectDir, (jarType == 'testJar') ? "build-test" : "dist")
 	manifest { attributes("Plugin-Main-Class": "plugins.Freetalk.Freetalk") }
 	

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 		junit('junit:junit:4.11') // Hamcrest is automatically included as transitive dependency.
 	else
 		junit files('/usr/share/java/junit4.jar', '/usr/share/java/hamcrest-core.jar')
+	testImplementation configurations.junit
 }
 
 task compileDb4o(type: Exec) {


### PR DESCRIPTION
_Please merge with `--ff-only` into `master`._

--- 

_This also contains the commits of the previous PR(s) to that branch._

---

Notice: The CI tests on Windows do still fail sometimes, but that is due to an actual unit test failure of the Freetalk unit tests on Windows.
It looks like a real bug and thus will require a separate investigation.
For now, expect Freetalk to not work properly on Windows.

---

Remaining GHA work:
- The remaining 3 FIXMEs added to the code by the `github-actions-part*` branches.  
- Investigate unrelated test failures on Windows, they fail most of the time for reasons which are likely actual breakage due to recent changes at Windows (they worked before), not merely a GHA issue.